### PR TITLE
docs: add FastAPI documentation section

### DIFF
--- a/docs/Python/FastAPI/01_handling_requests.md
+++ b/docs/Python/FastAPI/01_handling_requests.md
@@ -1,0 +1,112 @@
+---
+sidebar_position: 2
+---
+
+# Handle Requests and Responses in FastAPI
+
+This page shows common request patterns in FastAPI. The examples mirror the Flask flow in this project, so you can compare both frameworks side by side.
+
+## Capture path parameters
+
+FastAPI maps path parameters directly to function arguments.
+
+```python
+from fastapi import FastAPI
+
+app = FastAPI()
+
+
+@app.get("/hello_fastapi/{username}")
+def hello_user(username: str):
+    return {"message": f"Hello {username}!"}
+
+
+@app.get("/hello_fastapi/{username}/{age}")
+def user_info(username: str, age: int):
+    return {"message": f"Hello {username}, you are {age} years old!"}
+```
+
+- **`username: str`**: FastAPI treats it as text input.
+- **`age: int`**: FastAPI validates this as an integer. If invalid, it returns a 422 error.
+
+## Read query string parameters
+
+Use normal function parameters for query strings.
+
+```python
+from typing import Optional
+from fastapi import FastAPI
+
+app = FastAPI()
+
+
+@app.get("/hello_get")
+def hello_get(username: Optional[str] = None, userage: Optional[int] = None):
+    if username is None:
+        return {"message": "Who are you?"}
+
+    if userage is None:
+        return {"message": f"Hello {username}!"}
+
+    return {"message": f"Hello {username}! You are {userage} years old."}
+```
+
+- **Optional params**: Set defaults like `None`.
+- **Auto conversion**: FastAPI converts `userage` to `int` when possible.
+
+## Accept form submissions
+
+For HTML form posts, use `Form`.
+
+```python
+from fastapi import FastAPI, Form
+from fastapi.responses import HTMLResponse
+
+app = FastAPI()
+
+
+@app.get("/hello_post", response_class=HTMLResponse)
+def hello_post_form():
+    return """
+    <html>
+      <form action="/hello_post" method="POST">
+        <label>What is your name?</label><br>
+        <input type="text" name="username" />
+        <button type="submit">Submit</button>
+      </form>
+    </html>
+    """
+
+
+@app.post("/hello_post", response_class=HTMLResponse)
+def hello_post(username: str = Form(...)):
+    return f"""
+    <html>
+      <p>Hello {username}</p>
+      <a href="/hello_post">Back</a>
+    </html>
+    """
+```
+
+Install `python-multipart` if you use form fields:
+
+```bash
+pip install python-multipart
+```
+
+## Compare Flask vs FastAPI for request handling
+
+- **Flask**: You manually read from `request.args` / `request.form`.
+- **FastAPI**: Parameters are declared in the function signature with type hints.
+- **FastAPI advantage**: Better validation and auto-generated docs with less boilerplate.
+
+```mermaid
+graph TD
+    A[Incoming HTTP request] --> B{Framework}
+    B -->|Flask| C[Manual parsing from request object]
+    B -->|FastAPI| D[Typed function parameters]
+    C --> E[Custom validation]
+    D --> F[Automatic validation]
+    E --> G[Response]
+    F --> G[Response]
+```

--- a/docs/Python/FastAPI/0_intro.md
+++ b/docs/Python/FastAPI/0_intro.md
@@ -1,0 +1,61 @@
+---
+sidebar_position: 1
+---
+
+# Getting Started with FastAPI
+
+**FastAPI** is a modern Python web framework for building APIs quickly. It is great for data services because it gives you input validation, type hints, and automatic API docs out of the box.
+
+## Why FastAPI is useful
+
+If you already use Flask, FastAPI feels familiar, but it helps you move faster for API work.
+
+- **Type hints first**: Request and response data are validated automatically.
+- **Built-in docs**: Swagger UI (`/docs`) and ReDoc (`/redoc`) are generated for you.
+- **High performance**: Built on ASGI with Starlette and Pydantic.
+- **Clear API contracts**: Teams can see schema changes early.
+
+## Install and run your first app
+
+Install FastAPI and Uvicorn:
+
+```bash
+pip install fastapi uvicorn
+```
+
+Create `main.py`:
+
+```python
+from fastapi import FastAPI
+
+app = FastAPI()
+
+
+@app.get("/")
+def hello_fastapi():
+    return {"message": "Hello FastAPI!"}
+```
+
+Run the server:
+
+```bash
+uvicorn main:app --reload --host 0.0.0.0 --port 8000
+```
+
+Then open:
+
+- `http://localhost:8000/` for your API response
+- `http://localhost:8000/docs` for interactive Swagger UI
+- `http://localhost:8000/redoc` for ReDoc
+
+## Typical real-world flow
+
+In a data team project, you can expose ETL status or model results through API endpoints. Frontend apps and internal tools can consume the same API contract without guessing field names.
+
+```mermaid
+graph LR
+    A[Python service] --> B[FastAPI endpoint]
+    B --> C[Auto validation]
+    C --> D[JSON response]
+    D --> E[Frontend / Internal tool]
+```

--- a/docs/Python/FastAPI/_category_.json
+++ b/docs/Python/FastAPI/_category_.json
@@ -1,0 +1,7 @@
+{
+  "label": "FastAPI",
+  "link": {
+    "type": "generated-index",
+    "description": "Learn how to build modern Python APIs using FastAPI."
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a FastAPI counterpart to the existing Flask docs so readers can learn modern API patterns with the same hands-on style. 
- Give the team a concise reference for FastAPI examples (path/query/form handling), install/run instructions, and the auto-generated docs endpoints. 
- Help cross-compare Flask and FastAPI request-handling approaches to make it easier to migrate or choose between frameworks.

### Description
- Add a new docs category at `docs/Python/FastAPI/_category_.json` so FastAPI appears as its own section in the docs. 
- Add `docs/Python/FastAPI/0_intro.md` with a FastAPI introduction, install steps (`pip install fastapi uvicorn`), quick `main.py` example, run command (`uvicorn main:app --reload --host 0.0.0.0 --port 8000`), and a Mermaid flow diagram. 
- Add `docs/Python/FastAPI/01_handling_requests.md` that demonstrates path parameters, query parameters, HTML form handling (`Form` and `python-multipart`), and includes a concise Flask vs FastAPI comparison and Mermaid diagram.

### Testing
- Run the site build with `npm run build`, which completed successfully and generated static files for both `en` and `zh-Hant` locales. 
- A pre-existing tag warning was reported during the localized blog build, but the documentation build itself succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1b0ce480c833388b0f0d15d97d24e)