### PR TITLE
feat: Add GCP documentation under Cloud Service

### DIFF
--- a/docs/Cloud Service/GCP/00_Introduction.md
+++ b/docs/Cloud Service/GCP/00_Introduction.md
@@ -1,0 +1,87 @@
+---
+sidebar_position: 0
+---
+
+# Introduction to GCP
+
+Google Cloud Platform (GCP) is a suite of cloud services provided by Google. Instead of buying and managing your own servers, you rent compute power, storage, and databases from Google's global infrastructure. You only pay for what you use.
+
+If you have used AWS before, GCP works the same way. Most services have a direct equivalent on both platforms.
+
+## What Is Cloud Service?
+
+A cloud service lets you run infrastructure on someone else's servers over the internet. Instead of setting up a physical machine, you provision resources through a web console or CLI in minutes.
+
+For data engineers, cloud services matter because:
+
+- You can spin up a database or VM without touching hardware.
+- Storage and compute scale automatically with your workload.
+- Managed services (like BigQuery or Cloud SQL) handle maintenance for you.
+
+## What We Cover in This Section
+
+These pages walk through the core GCP services a data engineer uses day to day:
+
+| Page | Services |
+|------|----------|
+| Core Infrastructure | Compute Engine (VM), Cloud SQL, Firewall, gcloud CLI |
+| Cloud Storage & Secret Manager | GCS (object storage), Secret Manager |
+| BigQuery | Data warehouse, partitioning, Python client |
+| Machine Learning & AI | BigQuery ML, Vertex AI, Gemini integration |
+| DevOps & Deployment | Artifact Registry, Cloud Run |
+
+## Tools to Install Before You Start
+
+### 1. Google Cloud CLI (gcloud)
+
+The `gcloud` CLI is the main tool for managing GCP resources from your terminal. Install it first.
+
+Follow the official install guide for your OS: https://cloud.google.com/sdk/docs/install
+
+After installing, initialize and authenticate:
+
+```bash
+gcloud init
+gcloud auth login
+```
+
+Set your default project, region, and zone to avoid repeating them in every command:
+
+```bash
+gcloud config set project YOUR_PROJECT_ID
+gcloud config set compute/region asia-east1
+gcloud config set compute/zone asia-east1-b
+```
+
+### 2. gsutil
+
+`gsutil` comes bundled with the Google Cloud SDK. No separate install needed. You use it to interact with Cloud Storage buckets.
+
+```bash
+gsutil ls gs://my-bucket/
+```
+
+### 3. Python Libraries
+
+Most GCP services have a Python client library. Install what you need as you go through each section:
+
+```bash
+pip install google-cloud-bigquery       # BigQuery
+pip install google-cloud-storage        # Cloud Storage
+pip install google-cloud-secret-manager # Secret Manager
+pip install google-cloud-aiplatform     # Vertex AI
+```
+
+### 4. Docker
+
+Cloud Run deploys containerized applications, so you need Docker installed locally to build images.
+
+Download Docker Desktop from https://www.docker.com/products/docker-desktop/
+
+```bash
+docker --version  # verify install
+```
+
+---
+
+Once your tools are ready, start with [Core Infrastructure](./01_Core_Infrastructure.md) to set up your first VM and database on GCP.

--- a/docs/Cloud Service/GCP/01_Core_Infrastructure.md
+++ b/docs/Cloud Service/GCP/01_Core_Infrastructure.md
@@ -1,0 +1,102 @@
+---
+sidebar_position: 1
+---
+
+# Core Infrastructure: Compute, SQL & Networking
+
+This page covers the foundational GCP services you'll use most often: the CLI, virtual machines, firewall rules, and managed databases.
+
+## Google Cloud CLI (gcloud)
+
+The `gcloud` CLI is the main tool for managing GCP resources from the terminal. Think of it as the GCP equivalent of the AWS CLI.
+
+- **Authentication**: Run `gcloud auth login` to authenticate and set your active project.
+- **Default config**: Set a default region and zone so you don't have to repeat them in every command.
+
+```bash
+gcloud auth login
+gcloud config set project YOUR_PROJECT_ID
+gcloud config set compute/region asia-east1
+gcloud config set compute/zone asia-east1-b
+```
+
+## Compute Engine (Virtual Machines)
+
+Compute Engine lets you run VMs on Google's infrastructure. It is the GCP equivalent of AWS EC2.
+
+### Instance Management
+
+You can create instances with custom CPU and memory configurations through the console or CLI.
+
+```bash
+gcloud compute instances create my-vm \
+  --machine-type=e2-medium \
+  --zone=asia-east1-b \
+  --image-family=debian-11 \
+  --image-project=debian-cloud
+```
+
+### Remote Access
+
+There are three ways to connect to a VM:
+
+- **Console SSH button**: Quickest option, no setup needed.
+- **gcloud command**: `gcloud compute ssh INSTANCE_NAME --zone=ZONE`
+- **Custom SSH key**: Add your public key to the VM for direct SSH access.
+
+### VS Code Integration
+
+You can use VS Code with the **Remote - SSH** extension to develop directly on the VM, similar to how dev-containers work locally. This is useful when you need more compute power or want to keep the environment consistent.
+
+## Networking: Firewall Rules
+
+Firewall rules control inbound and outbound traffic to your VM instances. They work like AWS Security Groups.
+
+- **Rules**: Define allowed protocols (TCP, UDP, ICMP) and port numbers.
+- **Targeting**: Apply rules to the whole VPC or to specific instances using network tags.
+
+Common ports to open:
+
+| Port | Protocol | Use Case |
+|------|----------|----------|
+| 22   | TCP      | SSH      |
+| 80   | TCP      | HTTP     |
+| 443  | TCP      | HTTPS    |
+| 3306 | TCP      | MySQL    |
+
+```bash
+gcloud compute firewall-rules create allow-mysql \
+  --allow=tcp:3306 \
+  --target-tags=db-server \
+  --description="Allow MySQL access"
+```
+
+## Cloud SQL (Managed Relational Database)
+
+Cloud SQL is a fully managed database service that supports MySQL, PostgreSQL, and SQL Server. It is the GCP equivalent of AWS RDS.
+
+### Instance Setup
+
+When creating a Cloud SQL instance, you choose between:
+
+- **High Availability (Regional)**: Automatic failover across zones, best for production.
+- **Single Zone**: Lower cost, fine for development or non-critical workloads.
+
+### Connectivity
+
+- **Public IP**: Connect from outside GCP by adding your IP to the authorized networks list.
+- **Private IP**: Connect within a VPC without exposing the database to the internet.
+
+### Maintenance
+
+Google handles automated backups and patch management for you, so you don't need to manage these manually.
+
+```mermaid
+graph LR
+    A(gcloud CLI) --> B(Compute Engine VM)
+    B --> C{Access Type}
+    C -->|Public IP| D(Cloud SQL - Authorized Network)
+    C -->|Private IP| E(Cloud SQL - VPC Internal)
+    B --> F(Firewall Rules)
+    F -->|Network Tags| B
+```

--- a/docs/Cloud Service/GCP/02_Cloud_Storage_Secret_Manager.md
+++ b/docs/Cloud Service/GCP/02_Cloud_Storage_Secret_Manager.md
@@ -1,0 +1,90 @@
+---
+sidebar_position: 2
+---
+
+# Cloud Storage & Secret Manager
+
+This page covers how to store unstructured data with Google Cloud Storage and how to manage sensitive credentials with Secret Manager.
+
+## Google Cloud Storage (GCS)
+
+GCS is an object storage service built for high durability and scalability. It is the GCP equivalent of AWS S3. You organize data into **buckets**, and each bucket has a storage class based on how often you access the data.
+
+### Storage Classes
+
+| Class    | Use Case                              |
+|----------|---------------------------------------|
+| Standard | Frequently accessed data              |
+| Nearline | Accessed roughly once a month         |
+| Coldline | Accessed roughly once a quarter       |
+| Archive  | Long-term backup, rarely accessed     |
+
+### gsutil CLI
+
+`gsutil` is the command-line tool for interacting with GCS.
+
+```bash
+# Copy a file from local to GCS
+gsutil cp local_file.csv gs://my-bucket/path/
+
+# Copy from GCS to local
+gsutil cp gs://my-bucket/path/file.csv ./
+
+# Sync a local directory to a bucket (with deletion)
+gsutil rsync -d local_dir/ gs://my-bucket/path/
+```
+
+### Access Control
+
+- **IAM roles**: Control who can read or write to buckets at the project level.
+- **Signed URLs**: Generate temporary URLs to give time-limited access to specific objects without requiring a GCP account.
+
+## Secret Manager
+
+Secret Manager is a secure place to store sensitive information like API keys, passwords, and service account credentials. Instead of hardcoding credentials in your code, you pull them at runtime.
+
+### Why Use It
+
+If you put credentials directly in your code or `.env` files, it is easy to accidentally commit them to Git. Secret Manager keeps secrets out of version control entirely.
+
+### How It Works in Practice
+
+For Python or Docker applications, secrets are usually mapped to environment variables at runtime:
+
+```python
+from google.cloud import secretmanager
+
+client = secretmanager.SecretManagerServiceClient()
+name = "projects/MY_PROJECT/secrets/MY_SECRET/versions/latest"
+response = client.access_secret_version(request={"name": name})
+secret_value = response.payload.data.decode("UTF-8")
+```
+
+For Docker deployments, you can pass the secret as an environment variable:
+
+```bash
+export GOOGLE_APPLICATION_CREDENTIALS=$(gcloud secrets versions access latest --secret=my-sa-key)
+```
+
+### Secret Versioning
+
+Secrets support versioning. When you rotate a credential, you add a new version. Old versions stay available until you disable or delete them, so existing services keep working during the transition.
+
+## Security Best Practices
+
+- **Service accounts**: Create dedicated service accounts for each pipeline or application. Give each account only the permissions it actually needs (Least Privilege).
+- **Never commit key files**: Do not put JSON key files into Git. Use Secret Manager or workload identity federation instead.
+- **Rotate regularly**: Update secrets on a schedule and use versioning to avoid downtime during rotation.
+
+```mermaid
+graph LR
+    A(Python App / Docker) -->|Read at runtime| B(Secret Manager)
+    B --> C{Secret Types}
+    C --> D(API Keys)
+    C --> E(DB Passwords)
+    C --> F(Service Account JSON)
+    A -->|Store files| G(GCS Bucket)
+    G --> H{Storage Class}
+    H --> I(Standard)
+    H --> J(Nearline / Coldline / Archive)
+```

--- a/docs/Cloud Service/GCP/03_BigQuery.md
+++ b/docs/Cloud Service/GCP/03_BigQuery.md
@@ -1,0 +1,105 @@
+---
+sidebar_position: 3
+---
+
+# BigQuery: Data Engineering & Governance
+
+BigQuery is Google's serverless data warehouse. It is the GCP equivalent of AWS Redshift or Athena. This page covers table types, query optimization, and how to interact with BigQuery from Python.
+
+## Table Types
+
+BigQuery supports several table architectures, each with different trade-offs between cost and performance.
+
+### Native Tables
+
+Data is stored directly in BigQuery's columnar storage format. This gives you the best query performance and is the default choice for analytical workloads.
+
+### External Tables
+
+Data stays in an external source. BigQuery queries it in place without importing it. This is useful when you want to avoid duplication or when the data is already managed elsewhere.
+
+- **GCS External Tables**: Query CSV, Parquet, or JSON files stored in Cloud Storage buckets. Good for large raw datasets.
+- **Google Sheets External Tables**: Query a Google Sheet directly as a table. Useful for config tables or small datasets managed by non-technical teammates.
+
+## Partitioning & Clustering
+
+Large tables can get expensive to query. Partitioning and clustering help BigQuery scan less data.
+
+### Partitioning
+
+Partitioning splits a table into smaller segments so queries only scan the relevant portion.
+
+- **Ingestion-Time Partitioning**: BigQuery automatically partitions by the date data is loaded. You can filter with `_PARTITIONDATE`.
+- **Column-Based Partitioning**: Partition by a specific `DATE` or `TIMESTAMP` column in your data.
+
+```sql
+CREATE TABLE my_dataset.events
+PARTITION BY DATE(event_date)
+AS SELECT * FROM my_dataset.raw_events;
+```
+
+### Clustering
+
+Clustering sorts data within each partition by one or more columns. This speeds up queries that filter on those columns (e.g., user ID, region).
+
+```sql
+CREATE TABLE my_dataset.events
+PARTITION BY DATE(event_date)
+CLUSTER BY user_id
+AS SELECT * FROM my_dataset.raw_events;
+```
+
+## Python Integration
+
+Data engineers typically use the BigQuery Python client library to load and query data programmatically.
+
+### Authentication
+
+```python
+from google.oauth2 import service_account
+from google.cloud import bigquery
+
+credentials = service_account.Credentials.from_service_account_file("key.json")
+client = bigquery.Client(project="my-project", credentials=credentials)
+```
+
+### Run a Query
+
+```python
+query = """
+    SELECT user_id, COUNT(*) AS event_count
+    FROM `my-project.my_dataset.events`
+    WHERE DATE(event_date) = '2024-01-01'
+    GROUP BY user_id
+"""
+df = client.query(query).to_dataframe()
+```
+
+### Google Sheets Integration
+
+Use `pygsheets` to read data from Google Sheets and load it into BigQuery. This is a common pattern for automated reporting pipelines where business users update a sheet and the pipeline picks it up.
+
+```python
+import pygsheets
+from google.cloud import bigquery
+
+gc = pygsheets.authorize(service_file="key.json")
+sheet = gc.open("My Sheet").worksheet_by_title("Sheet1")
+df = sheet.get_as_df()
+
+client = bigquery.Client()
+job = client.load_table_from_dataframe(df, "my-project.my_dataset.config_table")
+job.result()
+```
+
+```mermaid
+graph LR
+    A(GCS Bucket) -->|External Table| B(BigQuery)
+    C(Google Sheets) -->|External Table| B
+    D(Python Client) -->|Load / Query| B
+    B --> E{Table Type}
+    E --> F(Native Table)
+    E --> G(External Table)
+    F --> H(Partitioned + Clustered)
+    H --> I(Optimized Query Cost)
+```

--- a/docs/Cloud Service/GCP/04_ML_AI.md
+++ b/docs/Cloud Service/GCP/04_ML_AI.md
@@ -1,0 +1,114 @@
+---
+sidebar_position: 4
+---
+
+# Machine Learning & AI: BQML & Vertex AI
+
+GCP lets you run machine learning and generative AI directly in your data environment. This page covers BigQuery ML for SQL-based modeling and Vertex AI for LLM integration.
+
+## BigQuery ML (BQML)
+
+BQML lets you build and run ML models using standard SQL. You don't need to export data or set up a separate training environment. The model lives inside BigQuery alongside your data.
+
+### Training a Model
+
+Use `CREATE MODEL` with a model type. For binary classification (e.g., predicting whether a user will purchase), use `LOGISTIC_REG`.
+
+```sql
+CREATE OR REPLACE MODEL my_dataset.purchase_model
+OPTIONS(model_type='LOGISTIC_REG', input_label_cols=['purchased'])
+AS
+SELECT
+  user_id,
+  session_duration,
+  page_views,
+  purchased
+FROM my_dataset.user_sessions
+WHERE DATE(event_date) < '2024-01-01';
+```
+
+BQML automatically handles:
+
+- **Null imputation**: Fills missing values with column means.
+- **One-hot encoding**: Converts string columns into numeric features.
+- **Standardization**: Normalizes numerical features.
+
+### Evaluating the Model
+
+```sql
+SELECT *
+FROM ML.EVALUATE(MODEL my_dataset.purchase_model,
+  (SELECT * FROM my_dataset.user_sessions WHERE DATE(event_date) >= '2024-01-01')
+);
+```
+
+Key metrics to check: **Accuracy**, **ROC AUC**, **Precision**, **Recall**.
+
+### Making Predictions
+
+```sql
+SELECT *
+FROM ML.PREDICT(MODEL my_dataset.purchase_model,
+  (SELECT * FROM my_dataset.new_users)
+);
+```
+
+### Feature Importance
+
+Inspect model weights to understand which features drive predictions most.
+
+```sql
+SELECT *
+FROM ML.WEIGHTS(MODEL my_dataset.purchase_model)
+ORDER BY ABS(weight) DESC;
+```
+
+## Vertex AI Integration
+
+Vertex AI is Google's platform for more advanced AI workloads. One powerful use case is connecting BigQuery to Vertex AI so you can run LLMs directly on your data using SQL.
+
+### Setting Up a Remote Connection
+
+First, create a remote connection between BigQuery and Vertex AI in the console or with the `bq` CLI. This lets BigQuery call Vertex AI models as if they were SQL functions.
+
+### Gemini on BigQuery
+
+Once the connection is set up, use `ML.GENERATE_TEXT` to call a Gemini model from a SQL query.
+
+```sql
+SELECT
+  feedback_id,
+  ML.GENERATE_TEXT(
+    MODEL my_dataset.gemini_model,
+    CONCAT(
+      'Analyze this customer feedback and return: sentiment (positive/negative/neutral), ',
+      'main topic, and a one-sentence summary.\n\nFeedback: ', feedback_text
+    ),
+    STRUCT(0.2 AS temperature, 1024 AS max_output_tokens)
+  ) AS ai_analysis
+FROM my_dataset.customer_feedback;
+```
+
+This is useful for:
+
+- **Sentiment analysis** on customer reviews or support tickets.
+- **Text summarization** at scale without leaving BigQuery.
+- **Category extraction** from unstructured logs.
+
+## Practical Applications
+
+- **Purchase propensity model**: Predict which users are likely to convert and pass the results to your marketing team.
+- **NL to SQL agent**: Build an agent that takes a natural language question and generates a BigQuery SQL query using Gemini.
+- **Behavior log categorization**: Automatically tag user actions by category without manual labeling.
+
+```mermaid
+graph LR
+    A(BigQuery Data) --> B(BQML)
+    B --> C{Model Tasks}
+    C --> D(Train - CREATE MODEL)
+    C --> E(Evaluate - ML.EVALUATE)
+    C --> F(Predict - ML.PREDICT)
+    A --> G(Vertex AI Connection)
+    G --> H(Gemini - ML.GENERATE_TEXT)
+    H --> I(Sentiment / Summary / Category)
+```

--- a/docs/Cloud Service/GCP/05_DevOps_Deployment.md
+++ b/docs/Cloud Service/GCP/05_DevOps_Deployment.md
@@ -1,0 +1,99 @@
+---
+sidebar_position: 5
+---
+
+# DevOps & Deployment: Containers, Registry & Cloud Run
+
+This page covers how to containerize a Python application, push the image to GCP, and deploy it as a serverless service using Cloud Run.
+
+## Artifact Registry
+
+Artifact Registry is where you store Docker images on GCP. It replaced Google Container Registry (GCR) and supports multiple artifact types including Docker images and Python packages.
+
+### Setting Up a Repository
+
+Create a repository scoped to a region (e.g., `asia-east1`):
+
+```bash
+gcloud artifacts repositories create my-repo \
+  --repository-format=docker \
+  --location=asia-east1 \
+  --description="Docker image repository"
+```
+
+### Authenticate Docker
+
+Before pushing images, authenticate Docker with your GCP credentials:
+
+```bash
+gcloud auth configure-docker asia-east1-docker.pkg.dev
+```
+
+### Build and Push an Image
+
+Tag your image using the registry URL structure, then push it:
+
+```bash
+docker build -t asia-east1-docker.pkg.dev/MY_PROJECT/my-repo/my-app:latest .
+docker push asia-east1-docker.pkg.dev/MY_PROJECT/my-repo/my-app:latest
+```
+
+## Cloud Run
+
+Cloud Run is a fully managed serverless platform for running containerized applications. You deploy a container image and GCP handles everything else: scaling, HTTPS, and infrastructure.
+
+### Key Characteristics
+
+- **Stateless**: The container must not rely on local disk state between requests.
+- **Port**: The app must listen on port `8080` by default (or set via the `PORT` env variable).
+- **Autoscaling**: Scales from zero to many instances automatically based on traffic. You only pay when requests are being handled.
+- **HTTPS**: Every Cloud Run service gets a built-in HTTPS endpoint.
+
+### Deploy a Service
+
+```bash
+gcloud run deploy my-service \
+  --image=asia-east1-docker.pkg.dev/MY_PROJECT/my-repo/my-app:latest \
+  --region=asia-east1 \
+  --platform=managed \
+  --allow-unauthenticated \
+  --set-env-vars="DB_HOST=YOUR_DB_IP,DB_NAME=mydb"
+```
+
+For secrets, reference Secret Manager instead of hardcoding values:
+
+```bash
+--set-secrets="DB_PASSWORD=my-db-password:latest"
+```
+
+## Full Workflow
+
+The typical workflow from code to production looks like this:
+
+1. **Build**: Write your application and create a `Dockerfile`.
+2. **Store**: Build the Docker image and push it to Artifact Registry.
+3. **Deploy**: Deploy the image to Cloud Run with the right environment variables.
+
+```dockerfile
+FROM python:3.11-slim
+
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+CMD ["python", "main.py"]
+```
+
+```mermaid
+graph LR
+    A(Write Code + Dockerfile) --> B(docker build)
+    B --> C(docker push)
+    C --> D(Artifact Registry)
+    D --> E(gcloud run deploy)
+    E --> F(Cloud Run Service)
+    F --> G(HTTPS Endpoint)
+    F --> H(Autoscaling)
+    F --> I(Secret Manager)
+```

--- a/docs/Cloud Service/GCP/_category_.json
+++ b/docs/Cloud Service/GCP/_category_.json
@@ -1,0 +1,7 @@
+{
+  "label": "GCP",
+  "link": {
+    "type": "generated-index",
+    "description": "Google Cloud Platform guides covering compute, storage, BigQuery, machine learning, and deployment workflows."
+  }
+}

--- a/docs/Cloud Service/_category_.json
+++ b/docs/Cloud Service/_category_.json
@@ -1,0 +1,7 @@
+{
+  "label": "Cloud Service",
+  "link": {
+    "type": "generated-index",
+    "description": "Learn how to use cloud services from major providers to build and manage data engineering infrastructure."
+  }
+}


### PR DESCRIPTION
## Summary

- Create `docs/Cloud Service/` and `docs/Cloud Service/GCP/` folder structure with `_category_.json` files for Docusaurus sidebar
- Add 6 GCP documentation pages based on class audio recording materials:
  0. **Introduction** (what is GCP/cloud, tools to install: gcloud, gsutil, Python libs, Docker)
  1. **Core Infrastructure** (Compute Engine, gcloud CLI, Firewall, Cloud SQL)
  2. **Cloud Storage & Secret Manager** (GCS storage classes, gsutil, Secret Manager usage)
  3. **BigQuery** (table types, partitioning/clustering, Python client)
  4. **Machine Learning & AI** (BQML training/evaluation/prediction, Vertex AI + Gemini integration)
  5. **DevOps & Deployment** (Artifact Registry, Cloud Run, full build-push-deploy workflow)

## What reviewers should know

- All pages follow the project's doc layout pattern (matching `docs/Data Pipeline/What is ETL.md` style): short sentences, bold key terms, code blocks with language tags, and Mermaid diagrams.
- Source material came from 5 AI-generated `.docx` files based on class audio recordings. Content was polished and restructured to match the site's writing style.

🤖 Generated with [Claude Code](https://claude.com/claude-code)